### PR TITLE
Make can message handling atomic by disabling interrupts

### DIFF
--- a/NG474-BOOT/Core/Src/canDriver.c
+++ b/NG474-BOOT/Core/Src/canDriver.c
@@ -177,6 +177,10 @@ void HAL_FDCAN_TxFifoEmptyCallback(FDCAN_HandleTypeDef *hfdcan)
 void HAL_FDCAN_RxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs)
 {
 	// Get message
+	/* Enter critical section: Disable interrupts to avoid any interruption during the loop */
+	uint32_t primask_bit;
+	primask_bit = __get_PRIMASK();
+	__disable_irq();
 	HAL_FDCAN_GetRxMessage(&hfdcan1, FDCAN_RX_FIFO0, &RxHeader, RxData);
 
 	// Check what type of message it is (Host, Data)
@@ -184,10 +188,14 @@ void HAL_FDCAN_RxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs)
 		{
 		case CAN_HOST:
 			can_host_handler(RxHeader.Identifier, RxData);
+			/* Exit critical section: restore previous priority mask */
+			__set_PRIMASK(primask_bit);
 			break;
 
 		case CAN_DATA:
 			can_data_handler(RxHeader.Identifier, RxData);
+			/* Exit critical section: restore previous priority mask */
+			__set_PRIMASK(primask_bit);
 			break;
 
 		default:


### PR DESCRIPTION
Interupts are disabled/enabled in HAL_FDCAN_RxFifo0Callback()

Interrupts are disabled after a can msg is received an re-enabled
after the message has been handled.